### PR TITLE
Allow benchmarking to start from shifted values

### DIFF
--- a/examples/benchmark_registration.py
+++ b/examples/benchmark_registration.py
@@ -96,6 +96,8 @@ if VIS:
     )
     tree_counts = tree_counts.sort_values(by="dataset_id", axis=0)
 
+    dataset_ids = field_trees.dataset_id.unique()
+
     with open(QUALITY_FILE, "r") as infile:
         quality = json.load(infile)
         quality = pd.DataFrame(
@@ -114,6 +116,7 @@ if VIS:
     CHM_shifts = CHM_shifts[high_counts_and_quality]
     MEE_shifts = MEE_shifts[high_counts_and_quality]
     target_shifts = target_shifts[high_counts_and_quality]
+    dataset_ids = dataset_ids[high_counts_and_quality]
 
     # Set error values to 0
     failed_MEE_shifts = np.logical_and(MEE_shifts[:, 0] == -12, MEE_shifts[:, 1] == -12)
@@ -125,6 +128,8 @@ if VIS:
     print(f"{failed_CHM_shifts.sum()} / {n_good_plots} CHM registrations failed")
     print(f"{failed_MEE_shifts.sum()} / {n_good_plots} MEE registrations failed")
     print(f"{failed_shifts_both.sum()} / {n_good_plots} plots failed for both")
+
+    print(f"The following datasets failed: {dataset_ids[failed_CHM_shifts]}")
 
     CHM_shifts = np.nan_to_num(CHM_shifts, 0)
     MEE_shifts[failed_MEE_shifts, :] = 0

--- a/examples/benchmark_registration.py
+++ b/examples/benchmark_registration.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
 import geopandas as gpd
 import matplotlib.pyplot as plt

--- a/examples/benchmark_registration.py
+++ b/examples/benchmark_registration.py
@@ -25,9 +25,12 @@ OUTPUT_MEE = Path(OUTPUT_FOLDER, "shifts_MEE.npy")
 OUTPUT_FOLDER.mkdir(exist_ok=True, parents=True)
 
 RANGES = (-12, 12, 0.25)
+# This should be set at least as large as the maximum shift, plus a reasonable buffer extra as
+# determined by the context of the algorithm.
+PLOT_BUFFER_DIST = 20
 
-RUN_MEE = True
-RUN_CHM = True
+RUN_MEE = False
+RUN_CHM = False
 VIS = True
 
 # An m3.2xl node has 64 CPU cores
@@ -50,7 +53,7 @@ if RUN_MEE:
         shift_CRS=SHIFT_CRS,
         vis_results=False,
         crop_to_plot_bounds=True,
-        plot_buffer_distance=10,
+        plot_buffer_distance=PLOT_BUFFER_DIST,
         CHM_approach=False,
         n_workers=N_WORKERS,
     )
@@ -79,7 +82,7 @@ if RUN_CHM:
         alignment_algorithm=find_best_shift_specialized,
         CHM_approach=True,
         crop_to_plot_bounds=True,
-        plot_buffer_distance=10,
+        plot_buffer_distance=PLOT_BUFFER_DIST,
         vis_plots=False,
         n_workers=N_WORKERS,
     )
@@ -129,7 +132,8 @@ if VIS:
     print(f"{failed_MEE_shifts.sum()} / {n_good_plots} MEE registrations failed")
     print(f"{failed_shifts_both.sum()} / {n_good_plots} plots failed for both")
 
-    print(f"The following datasets failed: {dataset_ids[failed_CHM_shifts]}")
+    print(f"The following datasets failed for CHM: {dataset_ids[failed_CHM_shifts]}")
+    print(f"The following datasets failed for MEE: {dataset_ids[failed_MEE_shifts]}")
 
     CHM_shifts = np.nan_to_num(CHM_shifts, 0)
     MEE_shifts[failed_MEE_shifts, :] = 0
@@ -155,8 +159,9 @@ if VIS:
         label=["MEE", "CHM", "no shift"],
     )
     plt.legend()
-    plt.title("Paired histogram")
+    plt.title("Histogram of registration quality")
     plt.xlabel("Errors from true shift (m)")
+    plt.ylabel("Number of plots")
     plt.show()
 
     plt.title("MEE error magnitudes vs. CHM error magnitudes")

--- a/examples/benchmark_registration.py
+++ b/examples/benchmark_registration.py
@@ -24,10 +24,10 @@ OUTPUT_MEE = Path(OUTPUT_FOLDER, "shifts_MEE.npy")
 
 OUTPUT_FOLDER.mkdir(exist_ok=True, parents=True)
 
-RANGES = (-20, 20, 0.5)
+RANGES = (-12, 12, 0.25)
 
-RUN_MEE = False
-RUN_CHM = False
+RUN_MEE = True
+RUN_CHM = True
 VIS = True
 
 # An m3.2xl node has 64 CPU cores

--- a/tree_registration_and_matching/add_attributes.py
+++ b/tree_registration_and_matching/add_attributes.py
@@ -1,7 +1,8 @@
 import geopandas as gpd
 import numpy as np
 
-from tree_registration_and_matching.register_MEE import match_trees_singlestratum
+from tree_registration_and_matching.register_MEE import \
+    match_trees_singlestratum
 from tree_registration_and_matching.utils import ensure_projected_CRS
 
 

--- a/tree_registration_and_matching/add_attributes.py
+++ b/tree_registration_and_matching/add_attributes.py
@@ -1,8 +1,7 @@
 import geopandas as gpd
 import numpy as np
 
-from tree_registration_and_matching.register_MEE import \
-    match_trees_singlestratum
+from tree_registration_and_matching.register_MEE import match_trees_singlestratum
 from tree_registration_and_matching.utils import ensure_projected_CRS
 
 

--- a/tree_registration_and_matching/benchmark.py
+++ b/tree_registration_and_matching/benchmark.py
@@ -14,10 +14,10 @@ from tree_registration_and_matching.utils import ensure_projected_CRS
 
 
 def compute_shift(
-    field_trees_file,
-    CHMs_or_detected_trees_file,
+    field_trees,
+    CHMs_or_detected_trees,
     plot_bounds,
-    plot_id,
+    dataset_id,
     alignment_algorithm,
     CHM_approach,
     crop_to_plot_bounds,
@@ -26,11 +26,10 @@ def compute_shift(
 ):
     """Contains the per-plot logic to support parrellization"""
     # Read the field trees and ensure that a projected CRS is used
-    field_trees = gpd.read_file(field_trees_file)
     plot_bounds.to_crs(field_trees.crs, inplace=True)
 
     if CHM_approach:
-        content_to_register_to = rio.open(CHMs_or_detected_trees_file)
+        content_to_register_to = rio.open(CHMs_or_detected_trees)
         if not content_to_register_to.crs.is_projected:
             raise ValueError(
                 "Raster does not have a projected CRS. This may cause errors in registration algorithms."
@@ -91,13 +90,13 @@ def compute_shift(
             plot_bounds.affine_transform(transform).plot(
                 ax=ax, facecolor="none", edgecolor="cyan", linewidth=3
             )
-            ax.set_title(f"CHM for plot_ID {plot_id}")
+            ax.set_title(f"CHM for dataset_ID {dataset_id}")
             plt.show()
     else:
         # Ensure that the field trees are in a projected (meters-based) CRS
         field_trees = ensure_projected_CRS(field_trees)
-        # Read the detected trees and convert to the same CRS as the field trees
-        content_to_register_to = gpd.read_file(CHMs_or_detected_trees_file)
+        # The data is already read
+        content_to_register_to = CHMs_or_detected_trees
         content_to_register_to.to_crs(field_trees.crs, inplace=True)
 
         # Crop to plot bounds if requested
@@ -116,7 +115,7 @@ def compute_shift(
                 ax=ax, c="b", markersize=2, label="detected trees"
             )
             field_trees.plot(ax=ax, c="r", markersize=2, label="surveyed trees")
-            plt.title(f"Visualization for {plot_id}")
+            plt.title(f"Visualization for {dataset_id}")
             plt.legend()
             plt.show()
 
@@ -140,8 +139,8 @@ def compute_shift(
 
 
 def score_approach(
-    field_trees_folder: str,
-    CHMs_or_detected_trees_folder: str,
+    field_trees_file: str,
+    CHMs_or_detected_trees: str,
     plots_file: str,
     alignment_algorithm=align_plot,
     CHM_approach: bool = False,
@@ -154,13 +153,15 @@ def score_approach(
     """Assess the quality of the shift on a set of plots.
 
     Args:
-        field_tree_folder (str):
-            The folder of geospatial files representing the surveyed trees, one per plot. The files
-            this folder should be named identically to those in `detected_tree_folder`.
-        CHMs_or_detected_trees_folder (str):
-            The folder of geospatial files representing either:
-                * Canopy height models, one per plot. This data will be in a raster format (e.g. .tif)
-                # Detected tree tops, one per plot. This data will be in a vector format (e.g. gpkg)
+        field_tree_file (str):
+            The file for geospatial files representing the surveyed trees. The `dataset_id` column
+            in this data should correspond to the filenames in `CHMs_or_detected_trees_folder`.
+        CHMs_or_detected_trees (str):
+            Either:
+                * A folder of canopy height models, one per plot. This data will be in a raster format
+                  (e.g. .tif)
+                * A file corresponding to detected tree tops, with `dataset_id` identifying the dataset.
+                  This data will be in a vector format (e.g. gpkg)
         plots_file (str):
             A path to a geopackage file with geometry representing the surveyed area. The 'plot_id'
             field represents which dataset (field trees plus CHMs or detected trees) files it
@@ -196,44 +197,52 @@ def score_approach(
 
     # Read all the plot bounds
     all_plot_bounds = gpd.read_file(plots_file)
+    all_field_trees = gpd.read_file(field_trees_file)
+
+    # Unique dataset IDs
+    dataset_IDs = sorted(all_field_trees.dataset_id.unique())
 
     # List all the files in both input folders
-    field_trees_files = sorted(field_trees_folder.glob("*"))
-    CHMs_or_detected_trees_files = sorted(CHMs_or_detected_trees_folder.glob("*"))
+    # TODO this needs to be updated
+    if CHM_approach:
+        CHMs_or_detected_trees_elements = sorted(CHMs_or_detected_trees.glob("*"))
+        if set(all_field_trees.dataset_id.unique()) != set(
+            [f.stem for f in CHMs_or_detected_trees_elements]
+        ):
+            raise ValueError(
+                "Different filenames between CHMs and field tree dataset IDs"
+            )
+    else:
+        detected_trees = gpd.read_file(CHMs_or_detected_trees)
+        CHMs_or_detected_trees_elements = [
+            detected_trees.query("dataset_id==dataset_id") for dataset_id in dataset_IDs
+        ]
 
     # Ensure there are the same number of files
-    if len(field_trees_files) != len(CHMs_or_detected_trees_files):
+    if len(dataset_IDs) != len(CHMs_or_detected_trees_elements):
         raise ValueError("Different number of files")
 
-    if set([f.stem for f in field_trees_files]) != set(
-        [f.stem for f in CHMs_or_detected_trees_files]
-    ):
-        raise ValueError("Different filenames")
-
-    plot_ids = []
+    field_trees_list = []
     plot_bounds_list = []
     # Iterate over files to extract plot bounds corresponding to each
-    for field_tree_file in field_trees_files:
+    for dataset_id in dataset_IDs:
         # Read the plot name and extract the plot bounds for this dataset
         # TODO, make optional to provide plot bounds
-        plot_id = field_tree_file.stem[:4]
-        plot_bounds = all_plot_bounds.query("plot_id == @plot_id")
-
-        plot_ids.append(plot_id)
-        plot_bounds_list.append(plot_bounds)
+        plot_bounds_list.append(all_plot_bounds.query("dataset_id == @dataset_id"))
+        field_trees_list.append(all_field_trees.query("dataset_id == @dataset_id"))
 
     # Compute the results with multiprocessing
     with Pool(n_workers) as p:
-        # The lists below are a bit of a hack because they just repeat the same q
-        n_files = len(field_trees_files)
+        # The lists below are a bit of a hack because they just repeat the same values
+        n_files = len(dataset_IDs)
         all_shifts = p.starmap(
             compute_shift,
             list(
                 zip(
-                    field_trees_files,
-                    CHMs_or_detected_trees_files,
+                    field_trees_list,
+                    CHMs_or_detected_trees_elements,
                     plot_bounds_list,
-                    plot_ids,
+                    dataset_IDs,
                     [alignment_algorithm] * n_files,
                     [CHM_approach] * n_files,
                     [crop_to_plot_bounds] * n_files,


### PR DESCRIPTION
This allows you to pass a dictionary of shifts, one per plot to the registration approach. It also makes some updates to properly use the dataset id as the unique identifier rather than a plot id. 