### PR TITLE
Add treetop to CHM registration entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,6 @@ COPY . /app
 
 # Install the module dependencies with poetry without creating a virtual environment
 RUN /root/.local/bin/poetry config virtualenvs.create false && /root/.local/bin/poetry install
+
+# Add the trees to CHM registration as the primary command
+CMD python /app/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ from python:3.12-slim
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y \
-    curl && \
+    curl libexpat1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install poetry

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -11,7 +11,9 @@ from tree_registration_and_matching.register_CHM import find_best_shift
 from tree_registration_and_matching.utils import ensure_projected_CRS
 
 MIN_TREE_HEIGHT = 5.0
-SHIFT_RANGE = (-10, 10, 1)
+
+COARSE_RANGE = (-10, 10, 1)
+FINE_RANGE = (-2, 2, 0.2)
 
 
 def cleanup_field_trees(
@@ -82,8 +84,8 @@ def register_trees_to_CHM(
     output_shift_summary: Optional[Path] = None,
     height_col: str = "height",
     min_tree_height: Optional[float] = MIN_TREE_HEIGHT,
-    x_range: tuple = (-10, 10, 1),
-    y_range: tuple = (-10, 10, 1),
+    coarse_range: tuple = COARSE_RANGE,
+    fine_range: tuple = FINE_RANGE,
     vis: bool = False,
 ):
     """Shift field-measured tree points to best align with a canopy height model (CHM).
@@ -110,12 +112,12 @@ def register_trees_to_CHM(
         min_tree_height (float, optional):
             The minimum height to use for registration. All trees are retained in the shifted output.
             Defaults to 5.0.
-        x_range (tuple):
-            Search range for x (easting) offsets as three values: start, stop, step.
+        coarse_range (tuple):
+            Search range for the initial coarse offsets as three values: start, stop, step.
             Defaults to (-10, 10, 1).
-        y_range (tuple):
-            Search range for y (northing) offsets as three values: start, stop, step.
-            Defaults to (-10, 10, 1).
+        fine_range (tuple):
+            Search range for the secondary fine shift offsets as three values: start, stop, step. This shift is
+            centered at the optimal value identified by the coarse shift. Defaults to (-2, 2, 0.2).
         vis (bool):
             If True, show interactive visualizations of the correlation surface.
             Defaults to False.
@@ -134,20 +136,38 @@ def register_trees_to_CHM(
     # Cleanup tree points, ensuring all have a height column
     cleaned_tree_points = cleanup_field_trees(tree_points, min_height=min_tree_height)
 
-    # Run registration
-    estimated_shift, metrics = find_best_shift(
+    # Run coarse registration
+    coarse_shift, coarse_metrics = find_best_shift(
         tree_points=cleaned_tree_points,
         CHM=CHM,
         height_col=height_col,
-        x_range=x_range,
-        y_range=y_range,
+        x_range=coarse_range,
+        y_range=coarse_range,
+        vis=vis,
+    )
+    # Run fine registration
+    # The range start and stops are shifted by the amount identified in the coarse shift
+    fine_shift, fine_metrics = find_best_shift(
+        tree_points=cleaned_tree_points,
+        CHM=CHM,
+        height_col=height_col,
+        x_range=(
+            fine_range[0] + coarse_shift[0],
+            fine_range[1] + coarse_shift[0],
+            fine_range[2],
+        ),
+        y_range=(
+            fine_range[0] + coarse_shift[1],
+            fine_range[1] + coarse_shift[1],
+            fine_range[2],
+        ),
         vis=vis,
     )
 
     if output_shifted_trees is not None:
         # Apply the shift and save
         tree_points.geometry = tree_points.geometry.translate(
-            xoff=estimated_shift[0], yoff=estimated_shift[1]
+            xoff=fine_shift[0], yoff=fine_shift[1]
         )
         # Transform back to original CRS
         tree_points.to_crs(original_CRS, inplace=True)
@@ -158,14 +178,18 @@ def register_trees_to_CHM(
 
     if output_shift_summary:
         # Store the shift and associated metadata
+        # Note that the optimal correlation represents the best value found in the fine shift,
+        # which corresponds to the reported shift. However, the ratio test is performed on the
+        # coarse grid, because this covers a larger spatial areas which is better at determining
+        # the quality of the shift compared to other options.
         summary_df = pd.DataFrame(
             [
                 {
-                    "estimated_shift_x": estimated_shift[0],
-                    "estimated_shift_y": estimated_shift[1],
+                    "estimated_shift_x": fine_shift[0],
+                    "estimated_shift_y": fine_shift[1],
                     "shift_CRS": shift_CRS,
-                    "optimal_correlation": metrics["best_correlation"],
-                    "ratio_quality_metric": metrics["ratio"],
+                    "optimal_correlation": fine_metrics["best_correlation"],
+                    "ratio_quality_metric": coarse_metrics["ratio"],
                     "n_shift_trees": len(cleaned_tree_points),
                     "CHM_file": CHM_file,
                 }
@@ -230,20 +254,20 @@ def parse_args():
         default=MIN_TREE_HEIGHT,
     )
     parser.add_argument(
-        "--x-range",
+        "--coarse-range",
         type=float,
         nargs=3,
-        default=SHIFT_RANGE,
+        default=COARSE_RANGE,
         metavar=("START", "STOP", "STEP"),
-        help="Search range for x offsets as three values: start stop step. Defaults to -10 10 1.",
+        help="Search range for the initial coarse offsets as three values: start stop step. Defaults to -10 10 1.",
     )
     parser.add_argument(
-        "--y-range",
+        "--fine-range",
         type=float,
         nargs=3,
-        default=SHIFT_RANGE,
+        default=FINE_RANGE,
         metavar=("START", "STOP", "STEP"),
-        help="Search range for y offsets as three values: start stop step. Defaults to -10 10 1.",
+        help="Search range for the secondary fine shift offsets as three values: start stop step. Defaults to -2 2 0.2.",
     )
     parser.add_argument(
         "--vis",

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -9,6 +9,8 @@ import rasterio as rio
 from tree_registration_and_matching.register_CHM import find_best_shift
 from tree_registration_and_matching.utils import ensure_projected_CRS
 
+MIN_TREE_HEIGHT = 5.0
+
 
 def cleanup_field_trees(
     ground_reference_trees: gpd.GeoDataFrame,
@@ -79,7 +81,7 @@ def register_trees_to_CHM(
     CHM_file: Path,
     output_shifted_trees: Path,
     height_col: str = "height",
-    min_tree_height: Optional[float] = None,
+    min_tree_height: Optional[float] = MIN_TREE_HEIGHT,
     x_range: tuple = (-10, 10, 1),
     y_range: tuple = (-10, 10, 1),
     vis: bool = False,
@@ -104,6 +106,7 @@ def register_trees_to_CHM(
             Defaults to "height".
         min_tree_height (float, optional):
             The minimum height to use for registration. All trees are retained in the shifted output.
+            Defaults to 5.0.
         x_range (tuple):
             Search range for x (easting) offsets as three values: start, stop, step.
             Defaults to (-10, 10, 1).
@@ -198,6 +201,7 @@ def parse_args():
     )
     parser.add_argument(
         "--min-tree-height", help="Only use trees above this height for registration."
+        , default=MIN_TREE_HEIGHT
     )
     parser.add_argument(
         "--x-range",

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -159,15 +159,17 @@ def register_trees_to_CHM(
     if output_shift_summary:
         # Store the shift and associated metadata
         summary_df = pd.DataFrame(
-            [{
-                "estimated_shift_x": estimated_shift[0],
-                "estimated_shift_y": estimated_shift[1],
-                "shift_CRS": shift_CRS,
-                "optimal_correlation": metrics["best_correlation"],
-                "ratio_quality_metric": metrics["ratio"],
-                "n_shift_trees": len(cleaned_tree_points),
-                "CHM_file": CHM_file,
-            }]
+            [
+                {
+                    "estimated_shift_x": estimated_shift[0],
+                    "estimated_shift_y": estimated_shift[1],
+                    "shift_CRS": shift_CRS,
+                    "optimal_correlation": metrics["best_correlation"],
+                    "ratio_quality_metric": metrics["ratio"],
+                    "n_shift_trees": len(cleaned_tree_points),
+                    "CHM_file": CHM_file,
+                }
+            ]
         )
 
         # Save out the summary

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 import rasterio as rio
 
 from tree_registration_and_matching.register_CHM import find_best_shift
@@ -37,7 +38,9 @@ def cleanup_field_trees(
         gpd.GeoDataFrame: The trees with the height_col completely filled and short trees optioanlly removed
     """
     # Remove any trees marked explicitly as dead
-    ground_reference_trees = ground_reference_trees[ground_reference_trees.live_dead != "D"]
+    ground_reference_trees = ground_reference_trees[
+        ground_reference_trees.live_dead != "D"
+    ]
 
     # First replace any missing height values with pre-computed allometric values
     nan_height = ground_reference_trees[height_col].isna()
@@ -75,7 +78,8 @@ def cleanup_field_trees(
 def register_trees_to_CHM(
     tree_points_file: Path,
     CHM_file: Path,
-    output_shifted_trees: Path,
+    output_shifted_trees: Optional[Path] = None,
+    output_shift_summary: Optional[Path] = None,
     height_col: str = "height",
     min_tree_height: Optional[float] = MIN_TREE_HEIGHT,
     x_range: tuple = (-10, 10, 1),
@@ -94,9 +98,12 @@ def register_trees_to_CHM(
             include a column with tree heights specified by `height_col`.
         CHM_file (Path):
             Path to the canopy height model raster file.
-        output_shifted_trees (Path):
-            Path to save the shifted tree points. The format is inferred from the file
-            extension (e.g. .gpkg, .shp, .geojson).
+        output_shifted_trees (Path, optional):
+            Path to save the shifted tree points. If not provided, the shifted points will not be saved.
+            Defaults to None.
+        output_shift_summary (Path, optional):
+            Path to save the summary of the shift. The file path should have a csv extension. If not provided,
+            the summary will not be provided. Defaults to None.
         height_col (str):
             Name of the column in the tree points file containing measured tree heights.
             Defaults to "height".
@@ -121,6 +128,8 @@ def register_trees_to_CHM(
     original_CRS = tree_points.crs
     # Ensure a projected CRS is used for registration
     tree_points = ensure_projected_CRS(tree_points)
+    # Record the CRS that the shift should be interpreted in
+    shift_CRS = tree_points.crs
 
     # Cleanup tree points, ensuring all have a height column
     cleaned_tree_points = cleanup_field_trees(tree_points, min_height=min_tree_height)
@@ -135,21 +144,35 @@ def register_trees_to_CHM(
         vis=vis,
     )
 
-    # Print metadata to stdout
-    print(f"Optimal shift (dx, dy): {estimated_shift}")
-    print(f"Best correlation: {metrics['best_correlation']}")
-    print(f"Quality ratio (second-best / best): {metrics['ratio']}")
+    if output_shifted_trees is not None:
+        # Apply the shift and save
+        tree_points.geometry = tree_points.geometry.translate(
+            xoff=estimated_shift[0], yoff=estimated_shift[1]
+        )
+        # Transform back to original CRS
+        tree_points.to_crs(original_CRS, inplace=True)
 
-    # Apply the shift and save
-    tree_points.geometry = tree_points.geometry.translate(
-        xoff=estimated_shift[0], yoff=estimated_shift[1]
-    )
-    # Transform back to original CRS
-    tree_points.to_crs(original_CRS, inplace=True)
+        # Save out
+        Path(output_shifted_trees).parent.mkdir(exist_ok=True, parents=True)
+        tree_points.to_file(output_shifted_trees)
 
-    # Save out
-    Path(output_shifted_trees).parent.mkdir(exist_ok=True, parents=True)
-    tree_points.to_file(output_shifted_trees)
+    if output_shift_summary:
+        # Store the shift and associated metadata
+        summary_df = pd.DataFrame(
+            [{
+                "estimated_shift_x": estimated_shift[0],
+                "estimated_shift_y": estimated_shift[1],
+                "shift_CRS": shift_CRS,
+                "optimal_correlation": metrics["best_correlation"],
+                "ratio_quality_metric": metrics["ratio"],
+                "n_shift_trees": len(cleaned_tree_points),
+                "CHM_file": CHM_file,
+            }]
+        )
+
+        # Save out the summary
+        Path(output_shift_summary).parent.mkdir(exist_ok=True, parents=True)
+        summary_df.to_csv(output_shift_summary, index=False)
 
 
 def parse_args():
@@ -187,8 +210,12 @@ def parse_args():
     parser.add_argument(
         "--output-shifted-trees",
         type=Path,
-        required=True,
         help="Path to save the shifted tree points (format inferred from extension).",
+    )
+    parser.add_argument(
+        "--output-shift-summary",
+        type=Path,
+        help="Path to save the summary of the shift. The file should have a .csv extension.",
     )
     parser.add_argument(
         "--height-col",

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -20,13 +20,13 @@ def cleanup_field_trees(
 ) -> gpd.GeoDataFrame:
     """
     Perform a variety of operations to standardize the data for matching
-    * Remove decaying and dead trees
+    * Remove dead trees
     * Ensure height is present, estimating allometrically from the "dbh" column if needed
     * Remove trees shorter than a cutoff, if requested
 
     Args:
         ground_reference_trees (gpd.GeoDataFrame):
-            must have the 'dbh' column and heights represented by the column noted in height_col
+            must have the 'dbh' and 'live_dead' columns and heights represented by the column noted in height_col
         min_height (Optional[float], optional):
             If provided, the data will be filtered to only trees with a height greater than this.
             Defaults to None.
@@ -36,13 +36,8 @@ def cleanup_field_trees(
     Returns:
         gpd.GeoDataFrame: The trees with the height_col completely filled and short trees optioanlly removed
     """
-    # The decay class specifies how severely a dead trees is decaying. At values above decay class 2,
-    # it is expected that the stem may be broken. This would cause issues estimating the height from
-    # DBH, and likely suggests a tree that will overall not be reconstructed well. Therefore, these
-    # trees are dropped prior to matching.
-    ground_reference_trees = ground_reference_trees[
-        ~(ground_reference_trees.decay_class > 2)
-    ]
+    # Remove any trees marked explicitly as dead
+    ground_reference_trees = ground_reference_trees[ground_reference_trees.live_dead != "D"]
 
     # First replace any missing height values with pre-computed allometric values
     nan_height = ground_reference_trees[height_col].isna()

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -1,11 +1,77 @@
 import argparse
 from pathlib import Path
+from typing import Optional
 
 import geopandas as gpd
+import numpy as np
 import rasterio as rio
 
 from tree_registration_and_matching.register_CHM import find_best_shift
 from tree_registration_and_matching.utils import ensure_projected_CRS
+
+
+def cleanup_field_trees(
+    ground_reference_trees: gpd.GeoDataFrame,
+    min_height: Optional[float] = None,
+    height_col: str = "height",
+) -> gpd.GeoDataFrame:
+    """
+    Perform a variety of operations to standardize the data for matching
+    * Remove decaying and dead trees
+    * Ensure height is present, estimating allometrically from the "dbh" column if needed
+    * Remove trees shorter than a cutoff, if requested
+
+    Args:
+        ground_reference_trees (gpd.GeoDataFrame):
+            must have the 'dbh' column and heights represented by the column noted in height_col
+        min_height (Optional[float], optional):
+            If provided, the data will be filtered to only trees with a height greater than this.
+            Defaults to None.
+        height_col (str, optional):
+            Which column to treat as the height. Defaults to "height".
+
+    Returns:
+        gpd.GeoDataFrame: The trees with the height_col completely filled and short trees optioanlly removed
+    """
+    # The decay class specifies how severely a dead trees is decaying. At values above decay class 2,
+    # it is expected that the stem may be broken. This would cause issues estimating the height from
+    # DBH, and likely suggests a tree that will overall not be reconstructed well. Therefore, these
+    # trees are dropped prior to matching.
+    ground_reference_trees = ground_reference_trees[
+        ~(ground_reference_trees.decay_class > 2)
+    ]
+
+    # First replace any missing height values with pre-computed allometric values
+    nan_height = ground_reference_trees[height_col].isna()
+    ground_reference_trees[nan_height][height_col] = ground_reference_trees[
+        nan_height
+    ].height_allometric
+
+    # For any remaining missing height values that have DBH, use an allometric equation to compute
+    # the height
+    nan_height = ground_reference_trees[height_col].isna()
+    # These parameters were fit on paired height, DBH data from this dataset.
+    allometric_height_func = lambda x: 1.3 + np.exp(
+        -0.3136489123372108 + 0.84623571 * np.log(x)
+    )
+    # Compute the allometric height and assign it
+    allometric_height = allometric_height_func(
+        ground_reference_trees[nan_height].dbh.to_numpy()
+    )
+    ground_reference_trees.loc[nan_height, height_col] = allometric_height
+
+    # Filter out any trees that still don't have height
+    ground_reference_trees = ground_reference_trees[
+        ~ground_reference_trees[height_col].isna()
+    ]
+
+    # Remove short trees if requested
+    if min_height is not None:
+        ground_reference_trees = ground_reference_trees[
+            ground_reference_trees[height_col] > min_height
+        ]
+
+    return ground_reference_trees
 
 
 def register_trees_to_CHM(
@@ -13,6 +79,7 @@ def register_trees_to_CHM(
     CHM_file: Path,
     output_shifted_trees: Path,
     height_col: str = "height",
+    min_tree_height: Optional[float] = None,
     x_range: tuple = (-10, 10, 1),
     y_range: tuple = (-10, 10, 1),
     vis: bool = False,
@@ -35,6 +102,8 @@ def register_trees_to_CHM(
         height_col (str):
             Name of the column in the tree points file containing measured tree heights.
             Defaults to "height".
+        min_tree_height (float, optional):
+            The minimum height to use for registration. All trees are retained in the shifted output.
         x_range (tuple):
             Search range for x (easting) offsets as three values: start, stop, step.
             Defaults to (-10, 10, 1).
@@ -54,9 +123,12 @@ def register_trees_to_CHM(
     # Ensure a projected CRS is used for registration
     tree_points = ensure_projected_CRS(tree_points)
 
+    # Cleanup tree points, ensuring all have a height column
+    cleaned_tree_points = cleanup_field_trees(tree_points, min_height=min_tree_height)
+
     # Run registration
     estimated_shift, metrics = find_best_shift(
-        tree_points=tree_points,
+        tree_points=cleaned_tree_points,
         CHM=CHM,
         height_col=height_col,
         x_range=x_range,
@@ -123,6 +195,9 @@ def parse_args():
         "--height-col",
         default="height",
         help="Name of the height column in the tree points file. Defaults to 'height'.",
+    )
+    parser.add_argument(
+        "--min-tree-height", help="Only use trees above this height for registration."
     )
     parser.add_argument(
         "--x-range",

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -10,6 +10,7 @@ from tree_registration_and_matching.register_CHM import find_best_shift
 from tree_registration_and_matching.utils import ensure_projected_CRS
 
 MIN_TREE_HEIGHT = 5.0
+SHIFT_RANGE = (-10, 10, 1)
 
 
 def cleanup_field_trees(
@@ -208,7 +209,7 @@ def parse_args():
         "--x-range",
         type=float,
         nargs=3,
-        default=(-10, 10, 1),
+        default=SHIFT_RANGE,
         metavar=("START", "STOP", "STEP"),
         help="Search range for x offsets as three values: start stop step. Defaults to -10 10 1.",
     )
@@ -216,7 +217,7 @@ def parse_args():
         "--y-range",
         type=float,
         nargs=3,
-        default=(-10, 10, 1),
+        default=SHIFT_RANGE,
         metavar=("START", "STOP", "STEP"),
         help="Search range for y offsets as three values: start stop step. Defaults to -10 10 1.",
     )

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -11,7 +11,7 @@ from tree_registration_and_matching.utils import ensure_projected_CRS
 def register_trees_to_CHM(
     tree_points_file: Path,
     CHM_file: Path,
-    output_file: Path,
+    output_shifted_trees: Path,
     height_col: str = "height",
     x_range: tuple = (-10, 10, 1),
     y_range: tuple = (-10, 10, 1),
@@ -29,7 +29,7 @@ def register_trees_to_CHM(
             include a column with tree heights specified by `height_col`.
         CHM_file (Path):
             Path to the canopy height model raster file.
-        output_file (Path):
+        output_shifted_trees (Path):
             Path to save the shifted tree points. The format is inferred from the file
             extension (e.g. .gpkg, .shp, .geojson).
         height_col (str):
@@ -77,7 +77,8 @@ def register_trees_to_CHM(
     tree_points.to_crs(original_CRS, inplace=True)
 
     # Save out
-    tree_points.to_file(output_file)
+    Path(output_shifted_trees).parent.mkdir(exist_ok=True, parents=True)
+    tree_points.to_file(output_shifted_trees)
 
 
 def parse_args():
@@ -113,7 +114,7 @@ def parse_args():
         help="Path to the canopy height model raster file.",
     )
     parser.add_argument(
-        "--output-file",
+        "--output-shifted-trees",
         type=Path,
         required=True,
         help="Path to save the shifted tree points (format inferred from extension).",

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -200,8 +200,9 @@ def parse_args():
         help="Name of the height column in the tree points file. Defaults to 'height'.",
     )
     parser.add_argument(
-        "--min-tree-height", help="Only use trees above this height for registration."
-        , default=MIN_TREE_HEIGHT
+        "--min-tree-height",
+        help="Only use trees above this height for registration.",
+        default=MIN_TREE_HEIGHT,
     )
     parser.add_argument(
         "--x-range",

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -1,0 +1,153 @@
+import argparse
+from pathlib import Path
+
+import geopandas as gpd
+import rasterio as rio
+
+from tree_registration_and_matching.register_CHM import find_best_shift
+from tree_registration_and_matching.utils import ensure_projected_CRS
+
+
+def register_trees_to_CHM(
+    tree_points_file: Path,
+    CHM_file: Path,
+    output_file: Path,
+    height_col: str = "height",
+    x_range: tuple = (-10, 10, 1),
+    y_range: tuple = (-10, 10, 1),
+    vis: bool = False,
+):
+    """Shift field-measured tree points to best align with a canopy height model (CHM).
+
+    Searches over a grid of (dx, dy) translations, selecting the shift that maximizes
+    the Pearson correlation between field-measured tree heights and CHM-sampled heights
+    at the shifted locations. The shifted trees are saved to the output file.
+
+    Args:
+        tree_points_file (Path):
+            Path to the input vector file containing field-measured tree points. Must
+            include a column with tree heights specified by `height_col`.
+        CHM_file (Path):
+            Path to the canopy height model raster file.
+        output_file (Path):
+            Path to save the shifted tree points. The format is inferred from the file
+            extension (e.g. .gpkg, .shp, .geojson).
+        height_col (str):
+            Name of the column in the tree points file containing measured tree heights.
+            Defaults to "height".
+        x_range (tuple):
+            Search range for x (easting) offsets as three values: start, stop, step.
+            Defaults to (-10, 10, 1).
+        y_range (tuple):
+            Search range for y (northing) offsets as three values: start, stop, step.
+            Defaults to (-10, 10, 1).
+        vis (bool):
+            If True, show interactive visualizations of the correlation surface.
+            Defaults to False.
+    """
+    # Load inputs
+    tree_points = gpd.read_file(tree_points_file)
+    CHM = rio.open(CHM_file)
+
+    # Record the CRS to transform back to at the end
+    original_CRS = tree_points.crs
+    # Ensure a projected CRS is used for registration
+    tree_points = ensure_projected_CRS(tree_points)
+
+    # Run registration
+    estimated_shift, metrics = find_best_shift(
+        tree_points=tree_points,
+        CHM=CHM,
+        height_col=height_col,
+        x_range=x_range,
+        y_range=y_range,
+        vis=vis,
+    )
+
+    # Print metadata to stdout
+    print(f"Optimal shift (dx, dy): {estimated_shift}")
+    print(f"Best correlation: {metrics['best_correlation']}")
+    print(f"Quality ratio (second-best / best): {metrics['ratio']}")
+
+    # Apply the shift and save
+    tree_points.geometry = tree_points.geometry.translate(
+        xoff=estimated_shift[0], yoff=estimated_shift[1]
+    )
+    # Transform back to original CRS
+    tree_points.to_crs(original_CRS, inplace=True)
+
+    # Save out
+    tree_points.to_file(output_file)
+
+
+def parse_args():
+    """Parse and return arguments.
+
+    Returns:
+        argparse.Namespace: Arguments
+    """
+    description = (
+        "Register field-measured tree points to a canopy height model (CHM) by "
+        "finding the (dx, dy) translation that maximizes the Pearson correlation "
+        "between field-measured and CHM-sampled tree heights. The shifted points "
+        "are saved to the output file. Metadata (best shift, correlation, quality "
+        "ratio) is printed to stdout.\n\n"
+        "All arguments are passed to "
+        "tree_registration_and_matching.entrypoints.register_trees_to_CHM.register_trees_to_CHM "
+        "which has the following documentation:\n\n" + register_trees_to_CHM.__doc__
+    )
+    parser = argparse.ArgumentParser(
+        description=description, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "--tree-points-file",
+        type=Path,
+        required=True,
+        help="Path to the input vector file of field-measured tree points.",
+    )
+    parser.add_argument(
+        "--CHM-file",
+        type=Path,
+        required=True,
+        help="Path to the canopy height model raster file.",
+    )
+    parser.add_argument(
+        "--output-file",
+        type=Path,
+        required=True,
+        help="Path to save the shifted tree points (format inferred from extension).",
+    )
+    parser.add_argument(
+        "--height-col",
+        default="height",
+        help="Name of the height column in the tree points file. Defaults to 'height'.",
+    )
+    parser.add_argument(
+        "--x-range",
+        type=float,
+        nargs=3,
+        default=(-10, 10, 1),
+        metavar=("START", "STOP", "STEP"),
+        help="Search range for x offsets as three values: start stop step. Defaults to -10 10 1.",
+    )
+    parser.add_argument(
+        "--y-range",
+        type=float,
+        nargs=3,
+        default=(-10, 10, 1),
+        metavar=("START", "STOP", "STEP"),
+        help="Search range for y offsets as three values: start stop step. Defaults to -10 10 1.",
+    )
+    parser.add_argument(
+        "--vis",
+        action="store_true",
+        help="Show interactive visualizations of the correlation surface.",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    register_trees_to_CHM(**vars(args))

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -37,7 +37,9 @@ def cleanup_field_trees(
         gpd.GeoDataFrame: The trees with the height_col completely filled and short trees optioanlly removed
     """
     # Remove any trees marked explicitly as dead
-    ground_reference_trees = ground_reference_trees[ground_reference_trees.live_dead != "D"]
+    ground_reference_trees = ground_reference_trees[
+        ground_reference_trees.live_dead != "D"
+    ]
 
     # First replace any missing height values with pre-computed allometric values
     nan_height = ground_reference_trees[height_col].isna()


### PR DESCRIPTION
This uses the tree height to CHM correlation to shift the tree top data and save it out. The first draft of this was created by Claude. It also adds this script as the Docker command.