### PR TITLE
Improve diagnostic metrics from CHM

### DIFF
--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -8,7 +8,10 @@ import pandas as pd
 import rasterio as rio
 
 from tree_registration_and_matching.register_CHM import find_best_shift
-from tree_registration_and_matching.utils import ensure_projected_CRS, ensure_height_is_present
+from tree_registration_and_matching.utils import (
+    ensure_projected_CRS,
+    ensure_height_is_present,
+)
 
 MIN_TREE_HEIGHT = 5.0
 
@@ -45,7 +48,9 @@ def cleanup_field_trees(
     ]
 
     # Make sure every tree has a height value, dropping any for which height cannot be imputed
-    ground_reference_trees = ensure_height_is_present(ground_reference_trees, height_col=height_col)
+    ground_reference_trees = ensure_height_is_present(
+        ground_reference_trees, height_col=height_col
+    )
 
     # Remove short trees if requested
     if min_height is not None:
@@ -177,6 +182,7 @@ def register_trees_to_CHM(
                     "ratio_quality_metric": coarse_metrics["ratio"],
                     "n_shift_trees": len(cleaned_tree_points),
                     "CHM_file": CHM_file,
+                    "average_error_frac": fine_metrics["average_error_frac"],
                 }
             ]
         )

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -8,7 +8,7 @@ import pandas as pd
 import rasterio as rio
 
 from tree_registration_and_matching.register_CHM import find_best_shift
-from tree_registration_and_matching.utils import ensure_projected_CRS
+from tree_registration_and_matching.utils import ensure_projected_CRS, ensure_height_is_present
 
 MIN_TREE_HEIGHT = 5.0
 
@@ -44,29 +44,8 @@ def cleanup_field_trees(
         ground_reference_trees.live_dead != "D"
     ]
 
-    # First replace any missing height values with pre-computed allometric values
-    nan_height = ground_reference_trees[height_col].isna()
-    ground_reference_trees[nan_height][height_col] = ground_reference_trees[
-        nan_height
-    ].height_allometric
-
-    # For any remaining missing height values that have DBH, use an allometric equation to compute
-    # the height
-    nan_height = ground_reference_trees[height_col].isna()
-    # These parameters were fit on paired height, DBH data from this dataset.
-    allometric_height_func = lambda x: 1.3 + np.exp(
-        -0.3136489123372108 + 0.84623571 * np.log(x)
-    )
-    # Compute the allometric height and assign it
-    allometric_height = allometric_height_func(
-        ground_reference_trees[nan_height].dbh.to_numpy()
-    )
-    ground_reference_trees.loc[nan_height, height_col] = allometric_height
-
-    # Filter out any trees that still don't have height
-    ground_reference_trees = ground_reference_trees[
-        ~ground_reference_trees[height_col].isna()
-    ]
+    # Make sure every tree has a height value, dropping any for which height cannot be imputed
+    ground_reference_trees = ensure_height_is_present(ground_reference_trees, height_col=height_col)
 
     # Remove short trees if requested
     if min_height is not None:

--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -9,8 +9,8 @@ import rasterio as rio
 
 from tree_registration_and_matching.register_CHM import find_best_shift
 from tree_registration_and_matching.utils import (
-    ensure_projected_CRS,
     ensure_height_is_present,
+    ensure_projected_CRS,
 )
 
 MIN_TREE_HEIGHT = 5.0

--- a/tree_registration_and_matching/register_CHM.py
+++ b/tree_registration_and_matching/register_CHM.py
@@ -66,6 +66,20 @@ def L2(sampled_heights, provided_heights):
     return -metric
 
 
+def average_frac_difference(sampled_heights, provided_heights):
+    # Returns the average fraction that the sampled height is from the provided height. Note that
+    # this is defined as the fraction different the smaller one is from the larger one, meaning both
+    # 0.5 vs. 1.0 and 2.0 vs. 1.0 both yield 0.5 difference.
+    mask = np.isfinite(sampled_heights) & np.isfinite(provided_heights)
+
+    ratios = sampled_heights[mask] / provided_heights[mask]
+    # Take the reciprocal of any over 1
+    ratios = np.where(ratios < 1, ratios, 1 / ratios)
+
+    # Take the mean of diffences from 1
+    return np.mean(1 - ratios)
+
+
 def compute_m2_m1_ratio(
     metrics_img: np.array,
     best_shift: tuple,
@@ -133,6 +147,18 @@ def compute_m2_m1_ratio(
     return ratio
 
 
+def sample_heights(CHM, xy_points, dx, dy):
+    """Convenience function to sample heights from the CHM after translating them by dx, dy"""
+    shifted_xy_points = xy_points + np.array([dx, dy])
+
+    # Query the CHM values at the shifted points
+    sampled_heights = np.array(
+        list(rio.sample.sample_gen(CHM, shifted_xy_points))
+    ).squeeze()
+
+    return sampled_heights
+
+
 def find_best_shift(
     tree_points,
     CHM,
@@ -196,16 +222,10 @@ def find_best_shift(
 
     # Iterate over the grid of possible shifts
     for dx, dy in shifts:
-        # Apply the shift to the initial tree locations
-        shifted_xy_points = xy_points + np.array([dx, dy])
+        sampled_heights = sample_heights(CHM=CHM, xy_points=xy_points, dx=dx, dy=dy)
 
-        # Query the CHM values at the shifted points
-        sampled_heights = np.array(
-            list(rio.sample.sample_gen(CHM, shifted_xy_points))
-        ).squeeze()
-
-        # Compute the metric comparing the provided and sampled heights
-        metrics.append(comparison_func(provided_heights, sampled_heights))
+        # Compute the metric comparing the sampled and provided heights
+        metrics.append(comparison_func(sampled_heights, provided_heights))
 
     # Create a 2D representation of the metrics, with the i dimension representing y shifts
     # TODO figure out if there's a top-bottom flip
@@ -232,6 +252,13 @@ def find_best_shift(
             vis=vis,
         )
 
+    # Compute fraction difference between real and predicted as a diagnostic metric
+    sampled_heights = sample_heights(
+        CHM=CHM, xy_points=xy_points, dx=best_shift[0], dy=best_shift[1]
+    )
+
+    average_error_frac = average_frac_difference(sampled_heights, provided_heights)
+
     return best_shift, {
         "best_shift": best_shift,
         "best_correlation": float(best_metric) if not np.isnan(best_metric) else np.nan,
@@ -239,4 +266,5 @@ def find_best_shift(
         "x_vals": x_vals,
         "y_vals": y_vals,
         "ratio": ratio,
+        "average_error_frac": average_error_frac,
     }

--- a/tree_registration_and_matching/utils.py
+++ b/tree_registration_and_matching/utils.py
@@ -64,7 +64,7 @@ def cdist(x, y):
 
 
 def ensure_height_is_present(
-    ground_reference_trees: gpd.GeoDataFrame,
+    ground_reference_trees: gpd.GeoDataFrame, height_col: str = "height"
 ) -> gpd.GeoDataFrame:
     """
     Ensure that every row has a height attribute with the following proceedure:
@@ -75,19 +75,20 @@ def ensure_height_is_present(
 
     Args:
         ground_reference_trees (gpd.GeoDataFrame): The trees to add height to
+        height_col (str): Which column represents the height. Defaults to "height".
 
     Returns:
         gpd.GeoDataFrame: The ground reference trees with every row having the height attributes
     """
     # First replace any missing height values with pre-computed allometric values
     nan_height = ground_reference_trees.height.isna()
-    ground_reference_trees[nan_height].height = ground_reference_trees[
+    ground_reference_trees.loc[nan_height, height_col] = ground_reference_trees[
         nan_height
     ].height_allometric
 
     # For any remaining missing height values that have DBH, use an allometric equation to compute
     # the height
-    nan_height = ground_reference_trees.height.isna()
+    nan_height = ground_reference_trees[height_col].isna()
     # These parameters were fit on paired height, DBH data from Western conifers dataset.
     allometric_height_func = lambda x: 1.3 + np.exp(
         -0.3136489123372108 + 0.84623571 * np.log(x)
@@ -96,11 +97,11 @@ def ensure_height_is_present(
     allometric_height = allometric_height_func(
         ground_reference_trees[nan_height].dbh.to_numpy()
     )
-    ground_reference_trees.loc[nan_height, "height"] = allometric_height
+    ground_reference_trees.loc[nan_height, height_col] = allometric_height
 
     # Filter out any trees that still don't have height
     ground_reference_trees = ground_reference_trees[
-        ~ground_reference_trees.height.isna()
+        ~ground_reference_trees[height_col].isna()
     ]
 
     return ground_reference_trees


### PR DESCRIPTION
This adds a new diagnostic metric to assess the quality of the shift, the ratio between the true and predicted heights. It also consolidates all logic for imputing heights in `utils.py` (closing #15) and creates a convenience function to sample from the CHM.

This was tested with:
```
python tree_registration_and_matching/entrypoints/register_trees_to_CHM.py \
  --CHM-file scratch/000119_chm-mesh.tif \
  --tree-points-file scratch/trees_0104.gpkg \
  --output-shift-summary scratch/shift-summary-new.csv
```