### PR TITLE
Ensure that the type of the height column doesn't change

### DIFF
--- a/tree_registration_and_matching/utils.py
+++ b/tree_registration_and_matching/utils.py
@@ -84,7 +84,7 @@ def ensure_height_is_present(
     nan_height = ground_reference_trees.height.isna()
     ground_reference_trees.loc[nan_height, height_col] = ground_reference_trees[
         nan_height
-    ].height_allometric
+    ].height_allometric.astype(float)
 
     # For any remaining missing height values that have DBH, use an allometric equation to compute
     # the height


### PR DESCRIPTION
In cases where the height values were being imputed with the `height_allometric` field, the type of `height` was being changed to `object`. This caused issues for a downstream `np.isfinite` call, shown below. 

```
Traceback (most recent call last):
  File "/app/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py", line 274, in <module>
    register_trees_to_CHM(**vars(args))
  File "/app/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py", line 124, in register_trees_to_CHM
    coarse_shift, coarse_metrics = find_best_shift(
                                   ^^^^^^^^^^^^^^^^
  File "/app/tree_registration_and_matching/register_CHM.py", line 228, in find_best_shift
    metrics.append(comparison_func(sampled_heights, provided_heights))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/tree_registration_and_matching/register_CHM.py", line 19, in corr_func
    mask = np.isfinite(sampled_heights) & np.isfinite(provided_heights)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

This fix was tested on the problematic dataset pairing `000112-0211` and worked.