### PR TITLE
Fix two small data-dependent bugs in the CHM registration code

### DIFF
--- a/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
+++ b/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py
@@ -151,8 +151,10 @@ def register_trees_to_CHM(
             vis=vis,
         )
     else:
+        # Default the values that are reported in the final metrics in the case where coarse
+        # registration failed.
         fine_shift = (np.nan, np.nan)
-        fine_metrics = {"best_correlation": np.nan}
+        fine_metrics = {"best_correlation": np.nan, "average_error_frac": np.nan}
 
     if output_shifted_trees is not None:
         # Apply the shift and save

--- a/tree_registration_and_matching/register_CHM.py
+++ b/tree_registration_and_matching/register_CHM.py
@@ -152,9 +152,10 @@ def sample_heights(CHM, xy_points, dx, dy):
     shifted_xy_points = xy_points + np.array([dx, dy])
 
     # Query the CHM values at the shifted points
-    sampled_heights = np.array(
-        list(rio.sample.sample_gen(CHM, shifted_xy_points))
-    ).squeeze()
+    sampled_heights = np.array(list(rio.sample.sample_gen(CHM, shifted_xy_points)))
+
+    # Remove the channel-wise dimension
+    sampled_heights = sampled_heights[:, 0]
 
     return sampled_heights
 


### PR DESCRIPTION
One bug related to not defaulting the `average_error_frac` if the coarse registration failed. The other was about `squeeze` being the wrong choice when there was only one sample.