### PR TITLE
Fix IndexError in ensure_projected_CRS when GeoDataFrame is empty

### DIFF
--- a/tree_registration_and_matching/utils.py
+++ b/tree_registration_and_matching/utils.py
@@ -24,8 +24,8 @@ def ensure_projected_CRS(geodata: gpd.GeoDataFrame):
     Returns:
         gpd.GeoDataGrame: projected geodataframe
     """
-    # If CRS is projected return immediately
-    if geodata.crs.is_projected:
+    # If empty or CRS is projected return immediately
+    if len(geodata) == 0 or geodata.crs.is_projected:
         return geodata
 
     # If CRS is geographic and not long-lat, convert it to long-lat


### PR DESCRIPTION
When testing the tree detection and evaluation Argo workflow, a dataset with zero ground truth trees caused `ensure_projected_CRS` to crash with an `IndexError`. This was because it tried to access `iloc[0]` to sample a coordinate for CRS inference, which fails on an empty GeoDataFrame. Added an early return for the empty case, consistent with the existing early return for already projected CRS.
